### PR TITLE
Fix composite index ordering on events table, aggregate_id then sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Places jar in `/framework/build/libs/framework.jar`
 ```
 ./gradlew run"
 ```
+or run `App.kt` from inside IntelliJ
+
+In either case, you'll need the following environment variables configured to point to postgres:
+```
+EVENT_STORE_DBNAME=kotlin_event_store;EVENT_STORE_HOST=localhost;EVENT_STORE_USERNAME=william.boxhall;EVENT_STORE_PORT=5432;EVENT_STORE_SSL=false
+```
+You sadly can't use in-memory h2sql to run the app because it doesn't support the `jsonb` data type
 
 # Run with Docker
 ```

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
@@ -99,8 +99,8 @@ val om = ObjectMapper().registerKotlinModule().registerModule(JodaModule()).conf
 object Events : Table() {
     val sequence = long("sequence").autoIncrement().index()
     val eventId = uuid("id")
-    val aggregateSequence = long("aggregate_sequence").primaryKey(0)
-    val aggregateId = uuid("aggregate_id").primaryKey(1)
+    val aggregateSequence = long("aggregate_sequence").primaryKey(1)
+    val aggregateId = uuid("aggregate_id").primaryKey(0)
     val aggregateType = varchar("aggregate_type", 128)
     val eventType = varchar("event_type", 128)
     val createdAt = date("createdAt")


### PR DESCRIPTION
```
11:40:31.080 [main] DEBUG Exposed - CREATE TABLE IF NOT EXISTS events ("sequence" BIGSERIAL NOT NULL, id uuid NOT NULL, aggregate_sequence BIGINT, aggregate_id uuid, aggregate_type VARCHAR(128) NOT NULL, event_type VARCHAR(128) NOT NULL, "createdAt" DATE NOT NULL, json_body jsonb NOT NULL, metadata jsonb NOT NULL, CONSTRAINT pk_Events PRIMARY KEY (aggregate_id, aggregate_sequence))
11:40:31.082 [main] DEBUG Exposed - CREATE INDEX events_sequence ON events ("sequence")
```