### PR TITLE
Asynchronous projector processes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "joda-time:joda-time:2.10.1"
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.8.9'
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.10'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.3.0'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.exposed:exposed:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:1.4.4"

--- a/framework/build.gradle
+++ b/framework/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compile "joda-time:joda-time:2.10.1"
     compile group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.8.9'
-    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.1.10'
+    testCompile 'io.kotlintest:kotlintest-runner-junit5:3.3.0'
     compile "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     compile "org.jetbrains.exposed:exposed:$exposed_version"
     implementation "io.github.microutils:kotlin-logging:1.4.4"

--- a/framework/src/main/kotlin/com/cultureamp/common/ExponentialBackoff.kt
+++ b/framework/src/main/kotlin/com/cultureamp/common/ExponentialBackoff.kt
@@ -1,0 +1,61 @@
+package com.cultureamp.common
+
+import arrow.core.Try
+import arrow.core.getOrElse
+import kotlin.math.min
+import kotlin.math.pow
+
+class ExponentialBackoff(
+	val idleTimeMs: Long = 5_000,
+	val failureBackoffMs: (attempt: Int) -> Long = exponentialBackoffAlgorithm(
+		600_000, 2
+	),
+	val sleeper: (millis: Long) -> Unit = { Thread.sleep(it) },
+	val onFailure: (error: Throwable, consecutiveFailures: Int) -> Unit
+) {
+	companion object {
+		val exponentialBackoffAlgorithm = { upperBound: Long, base: Int ->
+			{ consecutiveFailures: Int ->
+				min(upperBound, base.toDouble().pow(consecutiveFailures).toLong())
+			}
+		}
+	}
+
+	fun run(task: () -> Action) {
+		tailrec fun _run(consecutiveFailures: Int) {
+			val nextAction = Try {
+				task()
+			}.getOrElse { Action.Error(it) }
+
+			return when (nextAction) {
+				is Action.Wait -> {
+					sleeper(idleTimeMs)
+					_run(0)
+				}
+
+				is Action.Continue -> {
+					_run(0)
+				}
+
+				is Action.Error -> {
+					onFailure(nextAction.exception, consecutiveFailures + 1)
+					sleeper(failureBackoffMs(consecutiveFailures + 1))
+					_run(consecutiveFailures + 1)
+				}
+
+				is Action.Stop -> {
+					//Do nothing. This ends the recursive task loop.
+				}
+			}
+		}
+
+		return _run(0)
+	}
+}
+
+sealed class Action {
+	object Wait : Action()
+	object Continue : Action()
+	object Stop : Action()
+	data class Error(val exception: Throwable) : Action()
+}

--- a/framework/src/main/kotlin/com/cultureamp/common/Strings.kt
+++ b/framework/src/main/kotlin/com/cultureamp/common/Strings.kt
@@ -1,0 +1,16 @@
+package com.cultureamp.common
+
+fun String.toSnakeCase(): String {
+    var text: String = ""
+    var isFirst = true
+    this.forEach {
+        if (it.isUpperCase()) {
+            if (isFirst) isFirst = false
+            else text += "_"
+            text += it.toLowerCase()
+        } else {
+            text += it
+        }
+    }
+    return text
+}

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessor.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/AsyncEventProcessor.kt
@@ -1,0 +1,35 @@
+package com.cultureamp.eventsourcing
+
+import com.cultureamp.common.Action
+import com.cultureamp.common.ExponentialBackoff
+
+class AsyncEventProcessor(
+    private val eventStore: EventStore,
+    private val bookmarkStore: BookmarkStore,
+    private val bookmarkName: String,
+    private val eventListener: EventListener,
+    private val batchSize: Int = 1000
+) {
+
+    fun run() {
+        ExponentialBackoff(onFailure = { error, consecutiveFailures -> error.printStackTrace() }).run(::projectOneBatch)
+    }
+
+    private fun projectOneBatch(): Action {
+        val bookmark = bookmarkStore.findOrCreate(bookmarkName)
+
+        System.out.println("Polling for events for ${bookmarkName} from ${bookmark.sequence}")
+
+        val (count, sequence) = eventStore.getAfter(bookmark.sequence, batchSize).foldIndexed(
+            0 to bookmark.sequence
+        ) { index, acc, sequencedEvent ->
+            eventListener.handle(sequencedEvent.event)
+            index + 1 to sequencedEvent.sequence
+        }
+        bookmarkStore.save(bookmarkName, bookmark.copy(sequence = sequence))
+
+        System.out.println("Processed ${count} events for ${bookmarkName}")
+
+        return if (count >= batchSize) Action.Continue else Action.Wait
+    }
+}

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/BookmarkStore.kt
@@ -1,0 +1,19 @@
+package com.cultureamp.eventsourcing
+
+interface BookmarkStore {
+    fun findOrCreate(bookmarkName: String): Bookmark
+    fun save(bookmarkName: String, bookmark: Bookmark)
+
+}
+
+class InMemoryBookmarkStore : BookmarkStore {
+    val map = hashMapOf<String, Bookmark>().withDefault { Bookmark(0) }
+
+    override fun findOrCreate(bookmarkName: String) = map.getValue(bookmarkName)
+
+    override fun save(bookmarkName: String, bookmark: Bookmark) {
+        map[bookmarkName] = bookmark
+    }
+}
+
+data class Bookmark(val sequence: Long)

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -20,4 +20,6 @@ interface EventStore {
      * Replay all the events in the store on the project function, for an aggregateType
      */
     fun replay(aggregateType: String, project: (Event) -> Unit)
+
+    fun getAfter(sequence: Long, batchSize: Int) : Iterable<SequencedEvent>
 }

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -11,10 +11,7 @@ interface EventStore {
 
     // TODO this should be removed and implemented as separate threads/workers that poll the event-store
     fun notifyListeners(newEvents: List<Event>, aggregateId: UUID) {
-        newEvents.forEach { event ->
-            listeners.flatMap { it.handlers.filterKeys { it.isInstance(event.domainEvent) }.values }
-                .forEach { it(event.domainEvent, aggregateId) }
-        }
+        newEvents.forEach { event -> listeners.forEach { it.handle(event) } }
     }
 
     fun setup()

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -21,5 +21,5 @@ interface EventStore {
      */
     fun replay(aggregateType: String, project: (Event) -> Unit)
 
-    fun getAfter(sequence: Long, batchSize: Int) : Iterable<SequencedEvent>
+    fun getAfter(sequence: Long, batchSize: Int) : List<SequencedEvent>
 }

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/EventStore.kt
@@ -3,6 +3,7 @@ package com.cultureamp.eventsourcing
 import java.util.UUID
 
 interface EventStore {
+    @Deprecated("Use synchronousProjectors constructor parameter")
     val listeners: MutableList<EventListener>
 
     fun sink(newEvents: List<Event>, aggregateId: UUID, aggregateType: String): Either<CommandError, Unit>

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
@@ -188,6 +188,8 @@ data class Event(
     val domainEvent: DomainEvent
 )
 
+data class SequencedEvent(val event: Event, val sequence: Long)
+
 data class Metadata(
     val account_id: UUID,
     val user_id: UUID? = null,

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/Framework.kt
@@ -148,6 +148,10 @@ data class Configuration<CC : CreationCommand, CE : CreationEvent, Err : Command
 }
 
 data class EventListener(val handlers: Map<KClass<DomainEvent>, (DomainEvent, UUID) -> Any?>) {
+    fun handle(event: Event) {
+        handlers.filterKeys { it.isInstance(event.domainEvent) }.values.forEach { it(event.domainEvent, event.aggregateId)}
+    }
+
     @Suppress("UNCHECKED_CAST")
     companion object {
         inline fun <reified E : DomainEvent> from(noinline handle: (E, UUID) -> Any?): EventListener {

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
@@ -85,7 +85,7 @@ class PostgresDatabaseEventStore private constructor(private val db: Database) :
         }
     }
 
-    override fun getAfter(sequence: Long, batchSize: Int): Iterable<SequencedEvent> {
+    override fun getAfter(sequence: Long, batchSize: Int): List<SequencedEvent> {
         return transaction(db) {
             Events
                 .select {
@@ -93,7 +93,7 @@ class PostgresDatabaseEventStore private constructor(private val db: Database) :
                 }
                 .orderBy(Events.sequence)
                 .limit(batchSize)
-                .mapLazy(::rowToSequencedEvent)
+                .map(::rowToSequencedEvent)
         }
     }
 

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
@@ -58,18 +58,18 @@ class PostgresDatabaseEventStore private constructor(private val db: Database) :
         }
     }
 
-    private fun rowToEvent(row: ResultRow): Event = row.let {
+    private fun rowToSequencedEvent(row: ResultRow): SequencedEvent = row.let {
         val type = row[Events.eventType].asClass<DomainEvent>()
         val domainEvent = om.readValue(row[Events.body], type)
         val metadata = om.readValue(row[Events.metadata], Metadata::class.java)
-        Event(
+        SequencedEvent(Event(
             id = row[Events.eventId],
             aggregateId = row[Events.aggregateId],
             aggregateSequence = row[Events.aggregateSequence],
             createdAt = row[Events.createdAt],
             metadata = metadata,
             domainEvent = domainEvent
-        )
+        ), row[Events.sequence])
     }
 
     override fun replay(aggregateType: String, project: (Event) -> Unit) {
@@ -79,8 +79,21 @@ class PostgresDatabaseEventStore private constructor(private val db: Database) :
                     Events.aggregateType eq aggregateType
                 }
                 .orderBy(Events.sequence)
-                .mapLazy(::rowToEvent)
+                .mapLazy(::rowToSequencedEvent)
+                .mapLazy { it.event }
                 .forEach(project)
+        }
+    }
+
+    override fun getAfter(sequence: Long, batchSize: Int): Iterable<SequencedEvent> {
+        return transaction(db) {
+            Events
+                .select {
+                    Events.sequence greater sequence
+                }
+                .orderBy(Events.sequence)
+                .limit(batchSize)
+                .mapLazy(::rowToSequencedEvent)
         }
     }
 
@@ -89,7 +102,8 @@ class PostgresDatabaseEventStore private constructor(private val db: Database) :
             Events
                 .select { Events.aggregateId eq aggregateId }
                 .orderBy(Events.sequence)
-                .map(::rowToEvent)
+                .map(::rowToSequencedEvent)
+                .map { it.event }
         }
     }
 }

--- a/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
+++ b/framework/src/main/kotlin/com/cultureamp/eventsourcing/PostgresDatabaseEventStore.kt
@@ -10,14 +10,14 @@ import org.jetbrains.exposed.sql.transactions.transaction
 import org.joda.time.DateTime
 import java.util.*
 
-class PostgresDatabaseEventStore private constructor(private val db: Database) : EventStore {
+class PostgresDatabaseEventStore private constructor(private val db: Database, synchronousProjectors: List<EventListener>) : EventStore {
     companion object {
-        fun create(db: Database): PostgresDatabaseEventStore {
-            return PostgresDatabaseEventStore(db)
+        fun create(synchronousProjectors: List<EventListener>, db: Database): PostgresDatabaseEventStore {
+            return PostgresDatabaseEventStore(db, synchronousProjectors)
         }
     }
 
-    override val listeners: MutableList<EventListener> = mutableListOf()
+    override val listeners: MutableList<EventListener> = synchronousProjectors.toMutableList()
 
     override fun setup() {
         transaction(db) {

--- a/src/main/kotlin/App.kt
+++ b/src/main/kotlin/App.kt
@@ -1,6 +1,5 @@
 import com.cultureamp.eventsourcing.*
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.StdOutSqlLogger
 import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -8,6 +7,8 @@ import survey.demo.*
 import survey.design.*
 import survey.thing.AlwaysBoppable
 import survey.thing.ThingAggregate
+import kotlin.concurrent.thread
+import com.cultureamp.common.toSnakeCase
 
 fun main() {
     val eventStoreDatabase = Database.connect(DatabaseConfig.fromEnvironment("EVENT_STORE").toDataSource("event_store"))
@@ -60,13 +61,31 @@ fun main() {
     paymentSagaReactor.setup()
     val surveySagaReactor = SurveySagaReactor(commandGateway)
 
-    // TODO this should be done as separate threads/workers that poll the event-store
-    eventStore.listeners.addAll(listOf(
-        EventListener.from(paymentSagaReactor::react),
-        EventListener.from(surveySagaReactor::react),
+    val synchronousProjectors = listOf(
         EventListener.from(surveyNamesCommandProjector::project),
         EventListener.from(surveyCommandProjector::first, surveyCommandProjector::second)
-    ))
+    )
+
+    eventStore.listeners.addAll(synchronousProjectors)
+
+    val asynchronousReactors = listOf(
+        PaymentSagaReactor::class to EventListener.from(paymentSagaReactor::react),
+        SurveySagaReactor::class to EventListener.from(surveySagaReactor::react)
+    )
+
+    val bookmarkStore = InMemoryBookmarkStore()
+    asynchronousReactors
+        .map { it.first.java.canonicalName.toSnakeCase() to it.second }
+        .map {
+            thread(start = true, isDaemon = true, name = it.first) {
+                transaction(eventStoreDatabase) {
+                    addLogger(StdOutSqlLogger)
+                }
+                System.out.println("${it.first} reactor service starting")
+                AsyncEventProcessor(eventStore, bookmarkStore, it.first, it.second, 1).run()
+                System.out.println("${it.first} reactor service ending")
+            }
+        }
 
     Ktor.startEmbeddedCommandServer(commandGateway, eventStore)
 }

--- a/src/test/kotlin/com/cultureamp/common/ExponentialBackoffTest.kt
+++ b/src/test/kotlin/com/cultureamp/common/ExponentialBackoffTest.kt
@@ -1,0 +1,130 @@
+package com.cultureamp.common
+
+import com.cultureamp.common.Action.*
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+
+class ExponentialBackoffTest : FunSpec({
+	context("Successful task") {
+		test("Does not retry a successful task") {
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = {},
+				onFailure = { _: Throwable, _: Int -> Unit })
+
+			var runCount = 0
+			worker.run {
+				runCount += 1
+
+				Stop
+			}
+
+			runCount shouldBe 1
+		}
+
+		test("Will rerun the task without sleeping on Continue") {
+			var sleepCount = 0
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = { sleepCount += 1 },
+				onFailure = { _: Throwable, _: Int -> Unit })
+
+			var runCount = 0
+			worker.run {
+				runCount += 1
+
+				if (runCount < 5) {
+					Continue
+				} else {
+					Stop
+				}
+			}
+
+			runCount shouldBe 5
+			sleepCount shouldBe 0
+		}
+
+		test("Will rerun the task after sleeping on Wait") {
+			var sleepCount = 0
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = { sleepCount += 1 },
+				onFailure = { _: Throwable, _: Int -> Unit })
+
+			var runCount = 0
+			worker.run {
+				runCount += 1
+
+				if (runCount < 5) {
+					Wait
+				} else {
+					Stop
+				}
+			}
+
+			runCount shouldBe 5
+			sleepCount shouldBe 4
+		}
+	}
+
+	context("Failed task") {
+		test("Will log the reason for failure") {
+			var errorMessage = ""
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = {},
+				onFailure = { e: Throwable, _: Int -> errorMessage = e.message.toString() })
+
+			var shouldContinue = true
+			worker.run {
+				if (shouldContinue) {
+					shouldContinue = false
+					throw Throwable("boom")
+				} else {
+					Stop
+				}
+			}
+
+			errorMessage shouldBe "boom"
+		}
+
+		test("Will retry the failed task") {
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = {},
+				onFailure = { _: Throwable, _: Int -> Unit })
+
+			var runCount = 0
+			worker.run {
+				runCount += 1
+
+				if (runCount < 3) {
+					throw Throwable("boom")
+				} else {
+					Stop
+				}
+			}
+
+			runCount shouldBe 3
+		}
+
+		test("Will sleep on failed task") {
+			var sleepCount = 0
+			val worker = ExponentialBackoff(idleTimeMs = 0,
+				failureBackoffMs = { 0 },
+				sleeper = { sleepCount += 1 },
+				onFailure = { _: Throwable, _: Int -> Unit })
+
+			var runCount = 0
+			worker.run {
+				runCount += 1
+				if (runCount < 3) {
+					throw Throwable("boom")
+				} else {
+					Stop
+				}
+			}
+			sleepCount shouldBe 2
+		}
+	}
+})


### PR DESCRIPTION
This PR now provides the option to either provide a list of synchronous projectors directly as a constructor parameter to the event store, or create asynchronous projectors which can be spun up in threads (as demonstrated in the demo app, although perhaps they should be running as a totally separate service)